### PR TITLE
Add X-request-id if present

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -33,23 +33,23 @@ func NewCustomMiddleware(level logrus.Level, formatter logrus.Formatter, name st
 
 func (l *Middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	start := time.Now()
-	l.Logger.WithFields(logrus.Fields{
-		"method":     r.Method,
-		"request":    r.RequestURI,
-		"request_id": r.Header.Get("X-Request-Id"),
-		"remote":     r.RemoteAddr,
-	}).Info("started handling request")
+	entry := l.Logger.WithFields(logrus.Fields{
+		"request": r.RequestURI,
+		"method":  r.Method,
+		"remote":  r.RemoteAddr,
+	})
+
+	if reqID := r.Header.Get("X-Request-Id"); reqID != "" {
+		entry = entry.WithField("request_id", reqID)
+	}
+	entry.Info("started handling request")
 
 	next(rw, r)
 
 	latency := time.Since(start)
 	res := rw.(negroni.ResponseWriter)
-	l.Logger.WithFields(logrus.Fields{
+	entry.WithFields(logrus.Fields{
 		"status":      res.Status(),
-		"method":      r.Method,
-		"request":     r.RequestURI,
-		"request_id":  r.Header.Get("X-Request-Id"),
-		"remote":      r.RemoteAddr,
 		"text_status": http.StatusText(res.Status()),
 		"took":        latency,
 		fmt.Sprintf("measure#%s.latency", l.Name): latency.Nanoseconds(),

--- a/middleware.go
+++ b/middleware.go
@@ -34,9 +34,10 @@ func NewCustomMiddleware(level logrus.Level, formatter logrus.Formatter, name st
 func (l *Middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	start := time.Now()
 	l.Logger.WithFields(logrus.Fields{
-		"method":  r.Method,
-		"request": r.RequestURI,
-		"remote":  r.RemoteAddr,
+		"method":     r.Method,
+		"request":    r.RequestURI,
+		"request_id": r.Header.Get("X-Request-Id"),
+		"remote":     r.RemoteAddr,
 	}).Info("started handling request")
 
 	next(rw, r)
@@ -47,6 +48,7 @@ func (l *Middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 		"status":      res.Status(),
 		"method":      r.Method,
 		"request":     r.RequestURI,
+		"request_id":  r.Header.Get("X-Request-Id"),
 		"remote":      r.RemoteAddr,
 		"text_status": http.StatusText(res.Status()),
 		"took":        latency,


### PR DESCRIPTION
Log X-Request-id, generated by https://github.com/pilu/xrequestid or anything else (nginx, apache, etc.).
The header is optional and only displayed if present.