### PR TITLE
Handle X-Real-IP header if the server is behind a proxy

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -33,10 +33,17 @@ func NewCustomMiddleware(level logrus.Level, formatter logrus.Formatter, name st
 
 func (l *Middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	start := time.Now()
+
+	// Try to get the real IP
+	remoteAddr := r.RemoteAddr
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		remoteAddr = realIP
+	}
+
 	entry := l.Logger.WithFields(logrus.Fields{
 		"request": r.RequestURI,
 		"method":  r.Method,
-		"remote":  r.RemoteAddr,
+		"remote":  remoteAddr,
 	})
 
 	if reqID := r.Header.Get("X-Request-Id"); reqID != "" {


### PR DESCRIPTION
I'm not sure if it's better to keep the field "remote" and add an extra field "x_real_ip" or just update the "remote" value if the X-Real-IP is present.

What do you think ?
