### PR TITLE
Add ExcludeURL func to remove logging for some url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 sudo: false
 go:
-- 1.4.2
-- 1.5.1
+- 1.5
 - 1.6
 - tip
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 go:
 - 1.4.2
 - 1.5.1
+- 1.6
+- tip
 before_install:
 - go get -u golang.org/x/tools/cmd/cover
 - go get -u github.com/alecthomas/gometalinter

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -148,7 +148,10 @@ func TestMiddleware_ServeHTTP_logStartingFalse(t *testing.T) {
 
 func TestServeHTTPWithURLExcluded(t *testing.T) {
 	mw, rec, req := setupServeHTTP(t)
-	mw.ExcludeURL(req.URL.Path)
+	if err := mw.ExcludeURL(req.URL.Path); err != nil {
+		t.Fatalf("Can't exclude URL %q: %q", "req.URL.Path", err)
+	}
+
 	mw.ServeHTTP(rec, req, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(418)
 	})


### PR DESCRIPTION
closes #17 
This change is backward compatible, the API is just extended.