### PR TITLE
Add support for before and/or after func override

### DIFF
--- a/examples/hooks/example.go
+++ b/examples/hooks/example.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/negroni"
+	"github.com/meatballhat/negroni-logrus"
+)
+
+func main() {
+	r := http.NewServeMux()
+	r.HandleFunc(`/`, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "success!\n")
+	})
+
+	n := negroni.New()
+
+	nl := negronilogrus.NewMiddleware()
+	// override the default Before
+	nl.Before = customBefore
+	// wrap the default after, here replacing dots with underscores in keys
+	nl.After = makeNoDotAfter(nl.After)
+
+	n.Use(nl)
+	n.UseHandler(r)
+
+	n.Run(":9999")
+}
+
+func customBefore(entry *logrus.Entry, _ *http.Request, remoteAddr string) *logrus.Entry {
+	return entry.WithFields(logrus.Fields{
+		"REMOTE_ADDR": remoteAddr,
+		"YELLING":     true,
+	})
+}
+
+func makeNoDotAfter(after negronilogrus.AfterFunc) negronilogrus.AfterFunc {
+	return func(entry *logrus.Entry, res negroni.ResponseWriter, latency time.Duration, name string) *logrus.Entry {
+		return negronilogrus.EntryKeysReplace(after(entry, res, latency, name), ".", "_").WithField("ALL_DONE", true)
+	}
+}

--- a/middleware.go
+++ b/middleware.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -166,15 +165,4 @@ func DefaultAfter(entry *logrus.Entry, res negroni.ResponseWriter, latency time.
 		"took":        latency,
 		fmt.Sprintf("measure#%s.latency", name): latency.Nanoseconds(),
 	})
-}
-
-// EntryKeysReplace is a wee helper function for performing a strings.Replace on
-// every key in entry.Data
-func EntryKeysReplace(entry *logrus.Entry, old string, new string) *logrus.Entry {
-	for key, value := range entry.Data {
-		delete(entry.Data, key)
-		entry = entry.WithField(strings.Replace(key, old, new, -1), value)
-	}
-
-	return entry
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -230,13 +230,3 @@ func TestRealClock_Since(t *testing.T) {
 
 	assert.Regexp(t, "^1[0-5]\\.[0-9]+ms", since.String())
 }
-
-func TestEntryKeysReplace(t *testing.T) {
-	entry := logrus.New().WithFields(logrus.Fields{"lots.of.dots": 99, "...dottyfoo": false})
-	entry = EntryKeysReplace(entry, ".", "_")
-
-	assert.NotContains(t, entry.Data, "lots.of.dots")
-	assert.Contains(t, entry.Data, "lots_of_dots")
-	assert.NotContains(t, entry.Data, "...dottyfoo")
-	assert.Contains(t, entry.Data, "___dottyfoo")
-}


### PR DESCRIPTION
breaking out the existing behavior into `DefaultBefore` and `DefaultAfter`
funcs, plus adding a helper func to mutate all keys in the entry for cases like
newer Logstash that dislike dots in keys.

Closes #19 