### PR TITLE
Bug fix: next handler in chain won't be called if an ExcludedURL is matched

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -108,6 +108,7 @@ func (m *Middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 
 	for _, u := range m.excludeURLs {
 		if r.URL.Path == u {
+			next(rw, r)
 			return
 		}
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -208,11 +208,14 @@ func TestServeHTTPWithURLExcluded(t *testing.T) {
 		t.Fatalf("Can't exclude URL %q: %q", "req.URL.Path", err)
 	}
 
+	nextHandlerCalled := false
 	mw.ServeHTTP(rec, req, func(w http.ResponseWriter, r *http.Request) {
+		nextHandlerCalled = true
 		w.WriteHeader(418)
 	})
 	lines := strings.Split(strings.TrimSpace(mw.Logger.Out.(*bytes.Buffer).String()), "\n")
 	assert.Equal(t, []string{""}, lines)
+	assert.True(t, nextHandlerCalled, "The next http.HandlerFunc was not called!")
 }
 
 func TestRealClock_Now(t *testing.T) {


### PR DESCRIPTION
If an excluded URL is matched then the middleware simply returns - this means that chaining of http.HandlerFunc breaks.

The suggested fix is quite simple - call the next handler in the chain even if an excluded URL has been matched. (corresponding test has been enhanced to validate this use case)